### PR TITLE
Feature : BaseResponse설정 & 전역 예외 처리 체계

### DIFF
--- a/src/main/java/com/Just_112_More/PicPle/PicPleApplication.java
+++ b/src/main/java/com/Just_112_More/PicPle/PicPleApplication.java
@@ -1,11 +1,9 @@
 package com.Just_112_More.PicPle;
 
 import com.Just_112_More.PicPle.security.jwt.JwtProperties;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 
 @EnableConfigurationProperties(JwtProperties.class)
 @SpringBootApplication
@@ -13,13 +11,6 @@ public class PicPleApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(PicPleApplication.class, args);
-	}
-
-	@Bean
-	public CommandLineRunner testProps(JwtProperties jwtProperties) {
-		return args -> {
-			System.out.println(">>> TEST ACCESS_SECRET = " + jwtProperties.getAccessSecret());
-		};
 	}
 
 }

--- a/src/main/java/com/Just_112_More/PicPle/common/ApiError.java
+++ b/src/main/java/com/Just_112_More/PicPle/common/ApiError.java
@@ -1,8 +1,11 @@
 package com.Just_112_More.PicPle.common;
 
+import lombok.Getter;
+
+@Getter
 public class ApiError {
-    private String code;
-    private String message;
+    private final String code;
+    private final String message;
 
     public ApiError(String code, String message) {
         this.code = code;

--- a/src/main/java/com/Just_112_More/PicPle/common/ApiResponse.java
+++ b/src/main/java/com/Just_112_More/PicPle/common/ApiResponse.java
@@ -22,7 +22,7 @@ public class ApiResponse <T>{
                 .build();
     }
 
-    private static <T> ApiResponse<T> fail(T data, String code, String message){
+    public static <T> ApiResponse<T> fail(T data, String code, String message){
         return ApiResponse.<T>builder()
                 .isSuccess(false)
                 .data(data)

--- a/src/main/java/com/Just_112_More/PicPle/common/ApiResponse.java
+++ b/src/main/java/com/Just_112_More/PicPle/common/ApiResponse.java
@@ -1,7 +1,9 @@
 package com.Just_112_More.PicPle.common;
 
 import lombok.Builder;
+import lombok.Getter;
 
+@Getter
 public class ApiResponse <T>{
     private boolean isSuccess;
     private T data;

--- a/src/main/java/com/Just_112_More/PicPle/config/SecurityConfig.java
+++ b/src/main/java/com/Just_112_More/PicPle/config/SecurityConfig.java
@@ -17,6 +17,11 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import com.Just_112_More.PicPle.security.jwt.JwtAuthenticationEntryPoint;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -41,6 +46,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
                 .formLogin((auth) -> auth.disable())
                 .httpBasic(basic -> basic.disable())
@@ -67,5 +73,18 @@ public class SecurityConfig {
                 .sessionManagement((session) -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("*")); //주소미정
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
+        configuration.setAllowedHeaders(List.of("*")); // 세션,쿠키 없이 JWT 사용
+        configuration.setAllowCredentials(false);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/src/main/java/com/Just_112_More/PicPle/exception/CustomException.java
+++ b/src/main/java/com/Just_112_More/PicPle/exception/CustomException.java
@@ -1,0 +1,13 @@
+package com.Just_112_More.PicPle.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/Just_112_More/PicPle/exception/ErrorCode.java
+++ b/src/main/java/com/Just_112_More/PicPle/exception/ErrorCode.java
@@ -1,0 +1,21 @@
+package com.Just_112_More.PicPle.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // auth error
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근권한이 없습니다."),
+    NOT_LOGIN_USER(HttpStatus.FORBIDDEN, "로그인하지 않은 사용자입니다."),
+    INVALID_TOKEN_ERROR(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN_ERROR(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+    TOKEN_CORRECT_ERROR(HttpStatus.UNAUTHORIZED, "토큰이 올바르지 않습니다."),
+    TOKEN_GENERATION_ERROR(HttpStatus.UNAUTHORIZED, "토큰생성에 실패하였습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/Just_112_More/PicPle/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/Just_112_More/PicPle/exception/GlobalExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.Just_112_More.PicPle.exception;
+
+import com.Just_112_More.PicPle.common.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<?>> handleCustomException(CustomException customException){
+        return ResponseEntity
+                .status(customException.getErrorCode().getStatus())
+                .body(ApiResponse.fail(null, customException.getErrorCode().name(),
+                        customException.getErrorCode().getMessage() ));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<?>> handleOther(Exception exception){
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.fail(null, "INTERNAL_SERVER_ERROR", "서버 내부 오류"));
+    }
+
+}

--- a/src/main/java/com/Just_112_More/PicPle/security/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/Just_112_More/PicPle/security/jwt/JwtAccessDeniedHandler.java
@@ -1,5 +1,8 @@
 package com.Just_112_More.PicPle.security.jwt;
 
+import com.Just_112_More.PicPle.common.ApiResponse;
+import com.Just_112_More.PicPle.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.access.AccessDeniedException;
@@ -12,7 +15,16 @@ import java.io.IOException;
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
-        //필요한 권한이 없이 접근하려 할때 403
-        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+        //response.sendError(HttpServletResponse.SC_FORBIDDEN);
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+        ErrorCode errorCode = ErrorCode.ACCESS_DENIED;
+        String json = new ObjectMapper().writeValueAsString(
+                ApiResponse.fail(null, errorCode.name(), errorCode.getMessage())
+        );
+
+        response.getWriter().write(json);
     }
 }

--- a/src/main/java/com/Just_112_More/PicPle/security/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/Just_112_More/PicPle/security/jwt/JwtAccessDeniedHandler.java
@@ -17,14 +17,14 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
         //response.sendError(HttpServletResponse.SC_FORBIDDEN);
 
-        response.setContentType("application/json;charset=UTF-8");
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
 
         ErrorCode errorCode = ErrorCode.ACCESS_DENIED;
-        String json = new ObjectMapper().writeValueAsString(
-                ApiResponse.fail(null, errorCode.name(), errorCode.getMessage())
-        );
-
+        ApiResponse<?> errorResponse = ApiResponse.fail(null, errorCode.name(), errorCode.getMessage());
+        String json = new ObjectMapper().writeValueAsString(errorResponse);
         response.getWriter().write(json);
+
     }
 }

--- a/src/main/java/com/Just_112_More/PicPle/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/Just_112_More/PicPle/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,5 +1,8 @@
 package com.Just_112_More.PicPle.security.jwt;
 
+import com.Just_112_More.PicPle.common.ApiResponse;
+import com.Just_112_More.PicPle.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.core.AuthenticationException;
@@ -16,7 +19,15 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
                          HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
 
-        // 유효한 자격증명을 제공하지 않고 접근하려 할때 401
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        ErrorCode errorCode = ErrorCode.NOT_LOGIN_USER;
+
+        String json = new ObjectMapper().writeValueAsString(
+                ApiResponse.fail(null, errorCode.name(), errorCode.getMessage())
+        );
+
+        response.getWriter().write(json);
     }
 }

--- a/src/main/java/com/Just_112_More/PicPle/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/Just_112_More/PicPle/security/jwt/JwtAuthenticationEntryPoint.java
@@ -23,11 +23,8 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 
         ErrorCode errorCode = ErrorCode.NOT_LOGIN_USER;
-
-        String json = new ObjectMapper().writeValueAsString(
-                ApiResponse.fail(null, errorCode.name(), errorCode.getMessage())
-        );
-
+        ApiResponse<?> errorResponse = ApiResponse.fail(null, errorCode.name(), errorCode.getMessage());
+        String json = new ObjectMapper().writeValueAsString(errorResponse);
         response.getWriter().write(json);
     }
 }

--- a/src/main/java/com/Just_112_More/PicPle/security/jwt/JwtProperties.java
+++ b/src/main/java/com/Just_112_More/PicPle/security/jwt/JwtProperties.java
@@ -9,11 +9,6 @@ import org.springframework.stereotype.Component;
 @Setter
 @ConfigurationProperties(prefix = "jwt")
 public class JwtProperties {
-
-    public JwtProperties() {
-        System.out.println("로깅용 :: JwtProperties 생성자 호출됨!!!");
-    }
-
     private String header;
     private String accessSecret;
     private String refreshSecret;

--- a/src/main/java/com/Just_112_More/PicPle/security/jwt/JwtUtil.java
+++ b/src/main/java/com/Just_112_More/PicPle/security/jwt/JwtUtil.java
@@ -47,8 +47,6 @@ public class JwtUtil {
 
         this.accessKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(jwtProperties.getAccessSecret()));
         this.refreshKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(jwtProperties.getRefreshSecret()));
-        System.out.println("[DEBUG] accessSecret = " + jwtProperties.getAccessSecret());
-        System.out.println("[DEBUG] refreshSecret = " + jwtProperties.getRefreshSecret());
     }
 
     // AccessToken - 일반 요청 인증용


### PR DESCRIPTION
## 💡 Issue
- Closed : 
#28 #27 

## 🌱 Key changes
<!--변경사항 적기-->

- CORS 설정 추가: 웹 환경에서 프론트와의 통신을 위해 CORS 정책 설정

- 공통 응답 객체 ApiResponse, ApiError 도입
  - 성공/실패 응답 모두 동일한 구조로 관리 (isSuccess, data, error)
  - 실패 응답 시 명확한 에러코드 및 메시지 전달

- 전역 예외 처리 체계 도입 및 리팩토링
  - @RestControllerAdvice, ErrorCode, CustomException 도입
  - JwtAuthenticationEntryPoint, JwtAccessDeniedHandler 구현 → Spring Security 인증/인가 실패 시 커스텀 JSON 응답 반환
  - Security 설정에 커스텀 핸들러 등록 → 예외 응답 포맷 통일
  - ApiResponse.fail() 기반 에러 응답 일관화

- JSON 직렬화 문제 해결 
: 오류 응답 직렬화 문제 수정 → API 클라이언트에서 정상적으로 에러 메시지 수신 가능
## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->
SecurityConfig에서 exceptionHandling 설정이 적절하게 반영되었는지 확인 부탁드립니다. ( JwtAuthenticationEntryPoint 및 JwtAccessDeniedHandler )
전역 예외 처리 체계(RestControllerAdvice)에서 ApiResponse 기반 응답 포맷이 실제로 잘 적용되는지도 확인해 주세요.

✅ ApiResponse 사용예시
@blueoxygens @chowonjun606
컨트롤러에서 응답을 작성할 때 다음과 같은 구조를 참고해주세요!

[ 기본적인 try-catch 기반 응답 처리 ]
```markdown
try {
    // 성공 로직
    return ResponseEntity.ok(ApiResponse.success(result));
} catch (CustomException e) {
    // 실패로직
    return ResponseEntity.status(e.getErrorCode().getHttpStatus())
                         .body(ApiResponse.fail(null, e.getErrorCode().name(), e.getMessage()));
}
```

✅ 커스텀 에러 추가하는 과정
@blueoxygens @chowonjun606 
로직에서 발생할 수 있는 예외는 직접등록해서 다뤄주시고, 다음의 흐름을 따라 추가해 주세요!

(1) ErrorCode enum에 새로운 에러 정의
```markdown
INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
```
(2) 특정 상황에서 CustomException 던지
```markdown
throw new CustomException(ErrorCode.INVALID_TOKEN);
```

global exception에서 처리하는 예외 에러 메시지 형태입니다!
```markdown
{
  "isSuccess": false,
  "data": null,
  "error": {
    "code": "INVALID_TOKEN",
    "message": "유효하지 않은 토큰입니다."
  }
}
```
