### PR TITLE
Feature/my photo : 업로드&좋아요한 사진목록

### DIFF
--- a/src/main/java/com/Just_112_More/PicPle/like/repository/LikeRepository.java
+++ b/src/main/java/com/Just_112_More/PicPle/like/repository/LikeRepository.java
@@ -7,6 +7,8 @@ import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 @RequiredArgsConstructor
 public class LikeRepository {
@@ -28,5 +30,12 @@ public class LikeRepository {
                 .setParameter("photo", photo)
                 .getSingleResult();
         em.remove(like);
+    }
+
+    public List<Like> findLikesWithPhotoByUserId(Long userId) {
+        return em.createQuery(
+                        "SELECT l FROM Like l JOIN FETCH l.photo WHERE l.user.id = :userId", Like.class)
+                .setParameter("userId", userId)
+                .getResultList();
     }
 }

--- a/src/main/java/com/Just_112_More/PicPle/photo/controller/PhotoController.java
+++ b/src/main/java/com/Just_112_More/PicPle/photo/controller/PhotoController.java
@@ -141,7 +141,7 @@ public class PhotoController {
                 .imgUrl(s3Url + centerPhoto.getPhotoUrl())
                 .description(centerPhoto.getPhotoDesc())
                 .nickname(centerPhoto.getUser().getUserName())
-                .profileImgUrl(centerPhoto.getUser().getProfileUrl())
+                .profileImgUrl(centerPhoto.getUser().getProfilePath())
                 .likeCount(centerPhoto.getLikeCount())
                 .isLiked(false) // 실제로 로그인한 사용자가 있으면 여기서 체크
                 .address(centerPhoto.getLocationLabel())
@@ -156,7 +156,7 @@ public class PhotoController {
                         .imgUrl(s3Url + photo.getPhotoUrl())
                         .description(photo.getPhotoDesc())
                         .nickname(photo.getUser().getUserName())
-                        .profileImgUrl(photo.getUser().getProfileUrl())
+                        .profileImgUrl(photo.getUser().getProfilePath())
                         .likeCount(photo.getLikeCount())
                         .isLiked(false) // 실제로 로그인한 사용자가 있으면 여기서 체크
                         .address(photo.getLocationLabel())
@@ -191,7 +191,7 @@ public class PhotoController {
                     .imgUrl(s3Url + photo.getPhotoUrl())
                     .description(photo.getPhotoDesc())
                     .nickname(user.getUserName())
-                    .profileImgUrl(user.getProfileUrl())
+                    .profileImgUrl(user.getProfilePath())
                     .likeCount(photo.getLikeCount())
                     .isLiked(false)
                     .address(photo.getLocationLabel())

--- a/src/main/java/com/Just_112_More/PicPle/photo/dto/MyPagePhotoDto.java
+++ b/src/main/java/com/Just_112_More/PicPle/photo/dto/MyPagePhotoDto.java
@@ -1,0 +1,11 @@
+package com.Just_112_More.PicPle.photo.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MyPagePhotoDto {
+    private Long id;
+    private String imgUrl;
+}

--- a/src/main/java/com/Just_112_More/PicPle/photo/dto/uploadPhotoDto.java
+++ b/src/main/java/com/Just_112_More/PicPle/photo/dto/uploadPhotoDto.java
@@ -36,4 +36,20 @@ public class uploadPhotoDto {
         this.latitude = latitude;
         this.longitude = longitude;
     }
+
+    @Builder(builderMethodName = "userPageBuilder")
+    public uploadPhotoDto(Long id, String title, String imgUrl, String description,
+                          String nickname, String profileImgUrl, int likeCount,
+                          Boolean isLiked, String address, String createdAt ){
+        this.id = id;
+        this.title = title;
+        this.imgUrl = imgUrl;
+        this.description = description;
+        this.nickname = nickname;
+        this.profileImgUrl = profileImgUrl;
+        this.likeCount = likeCount;
+        this.isLiked = isLiked;
+        this.address = address;
+        this.createdAt = createdAt;
+    }
 }

--- a/src/main/java/com/Just_112_More/PicPle/photo/dto/uploadPhotoDto.java
+++ b/src/main/java/com/Just_112_More/PicPle/photo/dto/uploadPhotoDto.java
@@ -37,19 +37,4 @@ public class uploadPhotoDto {
         this.longitude = longitude;
     }
 
-    @Builder(builderMethodName = "userPageBuilder")
-    public uploadPhotoDto(Long id, String title, String imgUrl, String description,
-                          String nickname, String profileImgUrl, int likeCount,
-                          Boolean isLiked, String address, String createdAt ){
-        this.id = id;
-        this.title = title;
-        this.imgUrl = imgUrl;
-        this.description = description;
-        this.nickname = nickname;
-        this.profileImgUrl = profileImgUrl;
-        this.likeCount = likeCount;
-        this.isLiked = isLiked;
-        this.address = address;
-        this.createdAt = createdAt;
-    }
 }

--- a/src/main/java/com/Just_112_More/PicPle/user/controller/UserController.java
+++ b/src/main/java/com/Just_112_More/PicPle/user/controller/UserController.java
@@ -4,6 +4,7 @@ import com.Just_112_More.PicPle.common.ApiResponse;
 import com.Just_112_More.PicPle.exception.CustomException;
 import com.Just_112_More.PicPle.exception.ErrorCode;
 import com.Just_112_More.PicPle.photo.domain.Photo;
+import com.Just_112_More.PicPle.photo.dto.MyPagePhotoDto;
 import com.Just_112_More.PicPle.photo.dto.uploadPhotoDto;
 import com.Just_112_More.PicPle.photo.service.S3Service;
 import com.Just_112_More.PicPle.security.jwt.JwtUtil;
@@ -106,14 +107,14 @@ public class UserController {
     @GetMapping("/photos")
     public ResponseEntity<ApiResponse<?>> getUserPhotos(HttpServletRequest request){
         Long userId = extractAndValidateUserId(request);
-        List<uploadPhotoDto> photosByUser = userService.getPhotosByUser(userId);
+        List<MyPagePhotoDto> photosByUser = userService.getPhotosByUser(userId);
         return ResponseEntity.ok().body(ApiResponse.success(photosByUser));
     }
 
     @GetMapping("/likes")
     public ResponseEntity<ApiResponse<?>> getUserLikes(HttpServletRequest request){
         Long userId = extractAndValidateUserId(request);
-        List<uploadPhotoDto> LikePhotosByUser = userService.getLikedPhotosByUser(userId);
+        List<MyPagePhotoDto> LikePhotosByUser = userService.getLikedPhotosByUser(userId);
         return ResponseEntity.ok().body(ApiResponse.success(LikePhotosByUser));
     }
 

--- a/src/main/java/com/Just_112_More/PicPle/user/controller/UserController.java
+++ b/src/main/java/com/Just_112_More/PicPle/user/controller/UserController.java
@@ -3,6 +3,8 @@ package com.Just_112_More.PicPle.user.controller;
 import com.Just_112_More.PicPle.common.ApiResponse;
 import com.Just_112_More.PicPle.exception.CustomException;
 import com.Just_112_More.PicPle.exception.ErrorCode;
+import com.Just_112_More.PicPle.photo.domain.Photo;
+import com.Just_112_More.PicPle.photo.dto.uploadPhotoDto;
 import com.Just_112_More.PicPle.photo.service.S3Service;
 import com.Just_112_More.PicPle.security.jwt.JwtUtil;
 import com.Just_112_More.PicPle.user.dto.NicknameDto;
@@ -19,6 +21,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -103,9 +106,18 @@ public class UserController {
     @GetMapping("/photos")
     public ResponseEntity<ApiResponse<?>> getUserPhotos(HttpServletRequest request){
         Long userId = extractAndValidateUserId(request);
-
+        List<uploadPhotoDto> photosByUser = userService.getPhotosByUser(userId);
+        return ResponseEntity.ok().body(ApiResponse.success(photosByUser));
     }
 
+    @GetMapping("/likes")
+    public ResponseEntity<ApiResponse<?>> getUserLikes(HttpServletRequest request){
+        Long userId = extractAndValidateUserId(request);
+        List<uploadPhotoDto> LikePhotosByUser = userService.getLikedPhotosByUser(userId);
+        return ResponseEntity.ok().body(ApiResponse.success(LikePhotosByUser));
+    }
+
+    // 요청에서 accessToken추출 -> userId추출 -> 유효성(탈퇴여부) 체크
     private Long extractAndValidateUserId(HttpServletRequest request) {
         String token = jwtUtil.resolveToken(request);
         if (token == null) {

--- a/src/main/java/com/Just_112_More/PicPle/user/domain/User.java
+++ b/src/main/java/com/Just_112_More/PicPle/user/domain/User.java
@@ -34,7 +34,6 @@ public class User {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    // @Column(nullable = false, columnDefinition = "TINYINT(1) DEFAULT 0")
     private boolean isDeleted = false;
 
     private LocalDateTime userCreate;
@@ -59,8 +58,7 @@ public class User {
         this.userCreate = joinedAt;
     }
 
-    protected User() {
-    }
+    protected User() {}
 
     public static User fromOAuth(OAuthUserInfo info) {
         return new User(
@@ -94,10 +92,6 @@ public class User {
     public void reactivate() {
         this.isDeleted = false;
         this.deletedAt = null;
-    }
-
-    public boolean isValid() {
-        return !isDeleted || (deletedAt != null && deletedAt.isBefore(LocalDateTime.now()));
     }
 
 }

--- a/src/main/java/com/Just_112_More/PicPle/user/service/UserService.java
+++ b/src/main/java/com/Just_112_More/PicPle/user/service/UserService.java
@@ -83,6 +83,7 @@ public class UserService {
         return photos;
     }
 
+    // 탈퇴여부 체킹
     public Long validateUserId(Long userId){
         return userRepository.findeByIdAndIsDeletedFalse(userId)
                 .orElseThrow(()-> new CustomException(ErrorCode.USER_NOT_FOUND_OR_DELETED));


### PR DESCRIPTION
## 💡 Issue
- Resolved: #이슈번호

## 🌱 Key changes
<!--변경사항 적기-->
- 유저가 좋아요한 사진 & 업로드한 사진 요청: 유저의 좋아요한 사진과 업로드한 사진을 각각 처리하는 API 추가. user 엔티티에서 상호 참조 필드를 사용하여 데이터를 LAZY 로딩하도록 설정.
- MyPageDto 추가 ( 기존 상세보기 dto사용안함 )
- 1+N+N 문제 해결: Like와 Photo 엔티티를 JOIN FETCH로 묶어, DB 쿼리 횟수를 최소화하고 1+N+N 문제를 해결
