### PR TITLE
Feature/hot place

### DIFF
--- a/src/main/java/com/Just_112_More/PicPle/exception/ErrorCode.java
+++ b/src/main/java/com/Just_112_More/PicPle/exception/ErrorCode.java
@@ -39,7 +39,12 @@ public enum ErrorCode {
     INVALID_OAUTH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 SDK code입니다."),
     OAUTH_SERVER_ERROR(HttpStatus.BAD_GATEWAY, "OAuth 인증 서버에 연결할 수 없습니다."),
     OAUTH_RESPONSE_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "OAuth 사용자 정보 응답이 잘못되었습니다."),
-    REDIS_SAVE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "리프레시 토큰 저장에 실패했습니다.");
+
+    // redis 관련 에러
+    REDIS_SAVE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "redis 저장에 실패했습니다."),
+    REDIS_READ_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "redis 로드에 실패했습니다.")
+    ;
+
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/Just_112_More/PicPle/photo/controller/PhotoController.java
+++ b/src/main/java/com/Just_112_More/PicPle/photo/controller/PhotoController.java
@@ -22,7 +22,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @RestController
@@ -142,7 +141,7 @@ public class PhotoController {
                 .build())
                 .toList();
 
-        photosResponseDto responseDto = photosResponseDto.builder()
+        PhotosResponseDto responseDto = PhotosResponseDto.builder()
                 .photos(dtoList)
                 .build();
 

--- a/src/main/java/com/Just_112_More/PicPle/photo/controller/PhotoController.java
+++ b/src/main/java/com/Just_112_More/PicPle/photo/controller/PhotoController.java
@@ -10,6 +10,8 @@ import com.Just_112_More.PicPle.photo.service.PhotoService;
 import com.Just_112_More.PicPle.security.jwt.JwtUtil;
 import com.Just_112_More.PicPle.stat.domain.LocationStat;
 import com.Just_112_More.PicPle.stat.repository.LocationStatRepository;
+import com.Just_112_More.PicPle.stat.service.HotPlaceService;
+import com.Just_112_More.PicPle.stat.service.LocationStatService;
 import com.Just_112_More.PicPle.user.domain.User;
 import com.Just_112_More.PicPle.user.repository.UserRepository;
 
@@ -34,14 +36,15 @@ public class PhotoController {
 
     private final PhotoRepository photoRepository;
     private final PhotoService photoService;
+    private final LocationStatService locationStatService;
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
-    private final LocationStatRepository locationStatRepository;
+    private final HotPlaceService hotPlaceService;
 
     @PostMapping("/upload")
     public ResponseEntity<ApiResponse<?>> upload(
             HttpServletRequest request,
-            @RequestBody uploadPhotoRequestDto requestDto
+            @RequestBody UploadPhotoRequestDto requestDto
     ) {
         try {
             String token = jwtUtil.resolveToken(request);
@@ -54,41 +57,14 @@ public class PhotoController {
 
             // 좌표로 주소 변환
             List<String> addressList = photoService.reverseGeoCoding(requestDto.getLatitude(), requestDto.getLongitude());
-            //String address ="";
 
             // 사진 저장
-            Photo photo = Photo.builder()
-                    .photoTitle(requestDto.getTitle())
-                    .photoDesc(requestDto.getDescription())
-                    .photoUrl(requestDto.getPhotoUrl())
-                    .latitude(requestDto.getLatitude())
-                    .longitude(requestDto.getLongitude())
-                    .roadAddress(addressList.get(0))
-                    .locationLabel(addressList.get(1))
-                    .build();
-            photo.setUser(user);
-            photoRepository.save(photo);
+            Photo photo = photoService.uploadPhoto(requestDto, addressList, user);
 
             // 통계(LocationStat) 업데이트
             // localStat에서 검색후 있다면 찾고 증가, 없다면 새로 생성
-            LocationStat locationStat = locationStatRepository
-                    .findByLocationLabel(photo.getLocationLabel())
-                    .map(stat -> {
-                        // 이미 존재하면 +1
-                        stat.setPhotoCnt(stat.getPhotoCnt() + 1);
-                        stat.setLastUpdateTime(LocalDateTime.now());
-                        return stat;
-                    })
-                    .orElseGet(() -> {
-                        // 없으면 새로 생성
-                        LocationStat newStat = new LocationStat();
-                        newStat.setLocationLabel(photo.getLocationLabel());
-                        newStat.setRoadAddress(photo.getRoadAddress());
-                        newStat.setPhotoCnt(1);
-                        newStat.setLastUpdateTime(LocalDateTime.now());
-                        return newStat;
-                    });
-            locationStatRepository.save(locationStat);
+            LocationStat locationStat
+                    = locationStatService.uploadStat(photo.getLocationLabel(), photo.getRoadAddress());
 
             uploadPhotoDto dto = uploadPhotoDto.builder()
                     .id(photo.getId())

--- a/src/main/java/com/Just_112_More/PicPle/photo/domain/PhotoChangedEvent.java
+++ b/src/main/java/com/Just_112_More/PicPle/photo/domain/PhotoChangedEvent.java
@@ -1,0 +1,4 @@
+package com.Just_112_More.PicPle.photo.domain;
+
+public record PhotoChangedEvent(String locationLabel) {
+}

--- a/src/main/java/com/Just_112_More/PicPle/photo/dto/PhotosResponseDto.java
+++ b/src/main/java/com/Just_112_More/PicPle/photo/dto/PhotosResponseDto.java
@@ -5,11 +5,11 @@ import lombok.Getter;
 import java.util.List;
 
 @Getter
-public class photosResponseDto {
+public class PhotosResponseDto {
     private final List<uploadPhotoDto> photos;
 
     @Builder
-    public photosResponseDto(List<uploadPhotoDto> photos) {
+    public PhotosResponseDto(List<uploadPhotoDto> photos) {
         this.photos = photos;
     }
 }

--- a/src/main/java/com/Just_112_More/PicPle/photo/dto/UploadPhotoRequestDto.java
+++ b/src/main/java/com/Just_112_More/PicPle/photo/dto/UploadPhotoRequestDto.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 @Setter
 @Getter
 @NoArgsConstructor
-public class uploadPhotoRequestDto {
+public class UploadPhotoRequestDto {
     private String title;
     private String description;
     private String photoUrl;

--- a/src/main/java/com/Just_112_More/PicPle/photo/repository/PhotoRepository.java
+++ b/src/main/java/com/Just_112_More/PicPle/photo/repository/PhotoRepository.java
@@ -18,11 +18,12 @@ public class PhotoRepository {
     private final EntityManager em;
 
     @Transactional
-    public void save(Photo photo) {
+    public Photo save(Photo photo) {
         if(photo.getId()==null){
             em.persist(photo);
+            return photo;
         } else {
-            em.merge(photo);
+            return em.merge(photo);
         }
     }
 

--- a/src/main/java/com/Just_112_More/PicPle/photo/service/PhotoChangedListener.java
+++ b/src/main/java/com/Just_112_More/PicPle/photo/service/PhotoChangedListener.java
@@ -1,0 +1,23 @@
+package com.Just_112_More.PicPle.photo.service;
+
+import com.Just_112_More.PicPle.photo.domain.PhotoChangedEvent;
+import com.Just_112_More.PicPle.stat.service.HotPlaceService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PhotoChangedListener {
+    private final HotPlaceService hotPlaceService;
+
+    // DB 커밋후 실행
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onPhotoChanged(PhotoChangedEvent event) {
+        log.info("사진변경 이벤트 수신: {}", event.locationLabel());
+        hotPlaceService.checkListAndBroadcast();
+    }
+}

--- a/src/main/java/com/Just_112_More/PicPle/photo/service/PhotoService.java
+++ b/src/main/java/com/Just_112_More/PicPle/photo/service/PhotoService.java
@@ -3,6 +3,8 @@ package com.Just_112_More.PicPle.photo.service;
 import com.Just_112_More.PicPle.like.domain.Like;
 import com.Just_112_More.PicPle.like.repository.LikeRepository;
 import com.Just_112_More.PicPle.photo.domain.Photo;
+import com.Just_112_More.PicPle.photo.domain.PhotoChangedEvent;
+import com.Just_112_More.PicPle.photo.dto.UploadPhotoRequestDto;
 import com.Just_112_More.PicPle.photo.dto.uploadPhotoDto;
 import com.Just_112_More.PicPle.photo.repository.PhotoRepository;
 import com.Just_112_More.PicPle.user.domain.User;
@@ -14,6 +16,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,6 +38,21 @@ public class PhotoService {
 
     private final PhotoRepository photoRepository;
     private final LikeRepository likeRepository;
+
+    @Transactional
+    public Photo uploadPhoto(UploadPhotoRequestDto requestDto, List<String> addressList, User user) {
+        Photo photo = Photo.builder()
+                .photoTitle(requestDto.getTitle())
+                .photoDesc(requestDto.getDescription())
+                .photoUrl(requestDto.getPhotoUrl())
+                .latitude(requestDto.getLatitude())
+                .longitude(requestDto.getLongitude())
+                .roadAddress(addressList.get(0))
+                .locationLabel(addressList.get(1))
+                .build();
+        photo.setUser(user);
+        return photoRepository.save(photo);
+    }
 
     public List<String> reverseGeoCoding(Double lat, Double lon) {
         List<String> reverseGeoCoding = new ArrayList<>();

--- a/src/main/java/com/Just_112_More/PicPle/stat/controller/LocationStatController.java
+++ b/src/main/java/com/Just_112_More/PicPle/stat/controller/LocationStatController.java
@@ -4,6 +4,7 @@ import com.Just_112_More.PicPle.common.ApiResponse;
 import com.Just_112_More.PicPle.photo.dto.PhotosResponseDto;
 import com.Just_112_More.PicPle.stat.domain.LocationStat;
 import com.Just_112_More.PicPle.stat.dto.HotPlaceResponseList;
+import com.Just_112_More.PicPle.stat.service.HotPlaceService;
 import com.Just_112_More.PicPle.stat.service.LocationStatService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,10 +18,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class LocationStatController {
     private final LocationStatService locationStatService;
+    private final HotPlaceService hotPlaceService;
 
     @GetMapping("/top10")
     public ResponseEntity<ApiResponse<?>> getTop10LocationStats() {
-        HotPlaceResponseList top10LocationStats = locationStatService.getTop10LocationStats();
+        HotPlaceResponseList top10LocationStats = hotPlaceService.getTop10Cache();
         return ResponseEntity.ok(ApiResponse.success(top10LocationStats));
     }
 

--- a/src/main/java/com/Just_112_More/PicPle/stat/controller/LocationStatController.java
+++ b/src/main/java/com/Just_112_More/PicPle/stat/controller/LocationStatController.java
@@ -1,6 +1,7 @@
 package com.Just_112_More.PicPle.stat.controller;
 
 import com.Just_112_More.PicPle.common.ApiResponse;
+import com.Just_112_More.PicPle.photo.dto.PhotosResponseDto;
 import com.Just_112_More.PicPle.stat.domain.LocationStat;
 import com.Just_112_More.PicPle.stat.dto.HotPlaceResponseList;
 import com.Just_112_More.PicPle.stat.service.LocationStatService;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -20,5 +22,13 @@ public class LocationStatController {
     public ResponseEntity<ApiResponse<?>> getTop10LocationStats() {
         HotPlaceResponseList top10LocationStats = locationStatService.getTop10LocationStats();
         return ResponseEntity.ok(ApiResponse.success(top10LocationStats));
+    }
+
+    @GetMapping("/photo")
+    public ResponseEntity<ApiResponse<?>> getPhotoStats(
+            @RequestParam("location") String location
+    ) {
+        PhotosResponseDto photosResponseDto = locationStatService.getLocationPhotos(location);
+        return ResponseEntity.ok(ApiResponse.success(photosResponseDto));
     }
 }

--- a/src/main/java/com/Just_112_More/PicPle/stat/dto/HotPlaceResponse.java
+++ b/src/main/java/com/Just_112_More/PicPle/stat/dto/HotPlaceResponse.java
@@ -2,12 +2,15 @@ package com.Just_112_More.PicPle.stat.dto;
 
 import com.Just_112_More.PicPle.photo.dto.uploadPhotoDto;
 import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.util.List;
 
 @Builder
 @Getter
+@EqualsAndHashCode
 public class HotPlaceResponse {
     private int order;
     private String locationLabel;

--- a/src/main/java/com/Just_112_More/PicPle/stat/dto/HotPlaceResponse.java
+++ b/src/main/java/com/Just_112_More/PicPle/stat/dto/HotPlaceResponse.java
@@ -14,5 +14,4 @@ public class HotPlaceResponse {
     private int photoCnt;
     private String latitude;
     private String longitude;
-    private List<uploadPhotoDto> photos;
 }

--- a/src/main/java/com/Just_112_More/PicPle/stat/dto/HotPlaceResponseList.java
+++ b/src/main/java/com/Just_112_More/PicPle/stat/dto/HotPlaceResponseList.java
@@ -1,11 +1,13 @@
 package com.Just_112_More.PicPle.stat.dto;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
+@EqualsAndHashCode
 public class HotPlaceResponseList {
     private final List<HotPlaceResponse> hotplaces;
 

--- a/src/main/java/com/Just_112_More/PicPle/stat/service/HotPlaceInitalizer.java
+++ b/src/main/java/com/Just_112_More/PicPle/stat/service/HotPlaceInitalizer.java
@@ -15,7 +15,7 @@ public class HotPlaceInitalizer {
 
     @PostConstruct
     public void initTop10Cache() {
-        HotPlaceResponseList top10 = locationStatService.getTop10LocationStats();
+        HotPlaceResponseList top10 = locationStatService.calculateTop10FromDB();
         hotPlaceService.saveTop10Cache(top10);
         log.info("[초기화 작업] Redis에 초기 TOP10 핫플레이스 캐시 저장 완료");
     }

--- a/src/main/java/com/Just_112_More/PicPle/stat/service/HotPlaceInitalizer.java
+++ b/src/main/java/com/Just_112_More/PicPle/stat/service/HotPlaceInitalizer.java
@@ -1,0 +1,22 @@
+package com.Just_112_More.PicPle.stat.service;
+
+import com.Just_112_More.PicPle.stat.dto.HotPlaceResponseList;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class HotPlaceInitalizer {
+    private final LocationStatService locationStatService;
+    private final HotPlaceService hotPlaceService;
+
+    @PostConstruct
+    public void initTop10Cache() {
+        HotPlaceResponseList top10 = locationStatService.getTop10LocationStats();
+        hotPlaceService.saveTop10Cache(top10);
+        log.info("[초기화 작업] Redis에 초기 TOP10 핫플레이스 캐시 저장 완료");
+    }
+}

--- a/src/main/java/com/Just_112_More/PicPle/stat/service/HotPlaceService.java
+++ b/src/main/java/com/Just_112_More/PicPle/stat/service/HotPlaceService.java
@@ -5,6 +5,7 @@ import com.Just_112_More.PicPle.exception.ErrorCode;
 import com.Just_112_More.PicPle.stat.dto.HotPlaceResponseList;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
@@ -13,11 +14,12 @@ import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class HotPlaceService {
 
     private final RedisTemplate<String, String> redisTemplate;
     private final ObjectMapper objectMapper;
-    private final SimpMessagingTemplate messagingTemplate;
+    private final SimpMessagingTemplate simpleMessagingTemplate;
     private final LocationStatService locationStatService;
     private static final String TOP10_KEY = "top10::hotplaces";
 
@@ -40,5 +42,14 @@ public class HotPlaceService {
         }
     }
 
+    public void checkListAndBroadcast(){
+        HotPlaceResponseList oldList = getTop10Cache();
+        HotPlaceResponseList newList = locationStatService.calculateTop10FromDB();
 
+        if (!Objects.equals(oldList, newList)) {
+            saveTop10Cache(newList); // 새로운 내용으로 갱신하여 저장
+            simpleMessagingTemplate.convertAndSend("/topic/hot-places", newList);
+            log.info("Hotplaces TOP10 변경 감지 → Redis 갱신 및 broadcast 완료");
+        }
+    }
 }

--- a/src/main/java/com/Just_112_More/PicPle/stat/service/HotPlaceService.java
+++ b/src/main/java/com/Just_112_More/PicPle/stat/service/HotPlaceService.java
@@ -40,4 +40,5 @@ public class HotPlaceService {
         }
     }
 
+
 }

--- a/src/main/java/com/Just_112_More/PicPle/stat/service/HotPlaceService.java
+++ b/src/main/java/com/Just_112_More/PicPle/stat/service/HotPlaceService.java
@@ -50,6 +50,7 @@ public class HotPlaceService {
             saveTop10Cache(newList); // 새로운 내용으로 갱신하여 저장
             simpleMessagingTemplate.convertAndSend("/topic/hot-places", newList);
             log.info("Hotplaces TOP10 변경 감지 → Redis 갱신 및 broadcast 완료");
+            log.info("변경 감지됨...old={}, new={}", oldList, newList);
         }
     }
 }

--- a/src/main/java/com/Just_112_More/PicPle/stat/service/HotPlaceService.java
+++ b/src/main/java/com/Just_112_More/PicPle/stat/service/HotPlaceService.java
@@ -1,0 +1,43 @@
+package com.Just_112_More.PicPle.stat.service;
+
+import com.Just_112_More.PicPle.exception.CustomException;
+import com.Just_112_More.PicPle.exception.ErrorCode;
+import com.Just_112_More.PicPle.stat.dto.HotPlaceResponseList;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class HotPlaceService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final LocationStatService locationStatService;
+    private static final String TOP10_KEY = "top10::hotplaces";
+
+    public void saveTop10Cache(HotPlaceResponseList top10LocationStats) {
+        try{
+            String json = objectMapper.writeValueAsString(top10LocationStats);
+            redisTemplate.opsForValue().set(TOP10_KEY, json);
+        } catch (Exception e){
+            throw new CustomException(ErrorCode.REDIS_SAVE_FAIL);
+        }
+    }
+
+    public HotPlaceResponseList getTop10Cache(){
+        String json = redisTemplate.opsForValue().get(TOP10_KEY);
+        if (json == null) return null;
+        try{
+            return objectMapper.readValue(json, HotPlaceResponseList.class);
+        } catch (Exception e){
+            throw new CustomException(ErrorCode.REDIS_READ_FAIL);
+        }
+    }
+
+}

--- a/src/main/java/com/Just_112_More/PicPle/stat/service/LocationStatService.java
+++ b/src/main/java/com/Just_112_More/PicPle/stat/service/LocationStatService.java
@@ -1,6 +1,7 @@
 package com.Just_112_More.PicPle.stat.service;
 
 import com.Just_112_More.PicPle.photo.domain.Photo;
+import com.Just_112_More.PicPle.photo.domain.PhotoChangedEvent;
 import com.Just_112_More.PicPle.photo.dto.PhotosResponseDto;
 import com.Just_112_More.PicPle.photo.dto.uploadPhotoDto;
 import com.Just_112_More.PicPle.photo.service.PhotoService;
@@ -12,8 +13,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -28,6 +32,34 @@ public class LocationStatService {
 
     private final LocationStatRepository locationStatRepository;
     private final PhotoService photoService;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Transactional
+    public LocationStat uploadStat(String locationLabel, String roadAddress) {
+        LocationStat locationStat = locationStatRepository
+                .findByLocationLabel(locationLabel)
+                .map(stat -> {
+                    // 이미 존재하면 +1
+                    stat.setPhotoCnt(stat.getPhotoCnt() + 1);
+                    stat.setLastUpdateTime(LocalDateTime.now());
+                    return stat;
+                })
+                .orElseGet(() -> {
+                    // 없으면 새로 생성
+                    LocationStat newStat = new LocationStat();
+                    newStat.setLocationLabel(locationLabel);
+                    newStat.setRoadAddress(roadAddress);
+                    newStat.setPhotoCnt(1);
+                    newStat.setLastUpdateTime(LocalDateTime.now());
+                    return newStat;
+                });
+        LocationStat savedLocalStat = locationStatRepository.save(locationStat);
+
+        // 트랜잭션 커밋후 실행될 이벤트 등록
+        applicationEventPublisher.publishEvent(new PhotoChangedEvent(locationLabel));
+
+        return savedLocalStat;
+    }
 
     public HotPlaceResponseList calculateTop10FromDB() {
 

--- a/src/main/java/com/Just_112_More/PicPle/stat/service/LocationStatService.java
+++ b/src/main/java/com/Just_112_More/PicPle/stat/service/LocationStatService.java
@@ -1,6 +1,7 @@
 package com.Just_112_More.PicPle.stat.service;
 
 import com.Just_112_More.PicPle.photo.domain.Photo;
+import com.Just_112_More.PicPle.photo.dto.PhotosResponseDto;
 import com.Just_112_More.PicPle.photo.dto.uploadPhotoDto;
 import com.Just_112_More.PicPle.photo.service.PhotoService;
 import com.Just_112_More.PicPle.stat.domain.LocationStat;
@@ -50,35 +51,13 @@ public class LocationStatService {
             String latitude = geoData.get(0);  // 위도
             String longitude = geoData.get(1);  // 경도
 
-            // 사진 리스트 가져오기
-            List<Photo> photos = photoService.getPhotosByLocation(locationStat.getLocationLabel());
-            log.info("연결된 사진: {}개", photos.size());
-
-            List<uploadPhotoDto> photoList = photos.stream()
-                    .map( photo -> uploadPhotoDto.builder()
-                            .id(photo.getId())
-                            .title(photo.getPhotoTitle())
-                            .imgUrl(s3Url + photo.getPhotoUrl())
-                            .description(photo.getPhotoDesc())
-                            .nickname(photo.getUser().getUserName())
-                            .profileImgUrl(photo.getUser().getProfilePath())
-                            .likeCount(photo.getLikeCount())
-                            .isLiked(false) // 실제로 로그인한 사용자가 있으면 여기서 체크
-                            .address(photo.getLocationLabel())
-                            .createdAt(photo.getPhotoCreate().toString())
-                            .build()
-                    )
-                    .collect(Collectors.toList());
-
             HotPlaceResponse hotPlaceResponse = HotPlaceResponse.builder()
                     .order(i + 1)
                     .locationLabel(locationStat.getLocationLabel())
                     .photoCnt(locationStat.getPhotoCnt())
                     .latitude(latitude)
                     .longitude(longitude)
-                    .photos(photoList)
                     .build();
-
             results.add(hotPlaceResponse);
 
         }
@@ -90,4 +69,27 @@ public class LocationStatService {
 
     }
 
+    public PhotosResponseDto getLocationPhotos(String location) {
+        // 사진 리스트 가져오기
+        List<Photo> photos = photoService.getPhotosByLocation(location);
+        log.info("연결된 사진: {}개", photos.size());
+
+        List<uploadPhotoDto> photoList = photos.stream()
+                .map( photo -> uploadPhotoDto.builder()
+                        .id(photo.getId())
+                        .title(photo.getPhotoTitle())
+                        .imgUrl(s3Url + photo.getPhotoUrl())
+                        .description(photo.getPhotoDesc())
+                        .nickname(photo.getUser().getUserName())
+                        .profileImgUrl(photo.getUser().getProfilePath())
+                        .likeCount(photo.getLikeCount())
+                        .isLiked(false) // 실제로 로그인한 사용자가 있으면 여기서 체크
+                        .address(photo.getLocationLabel())
+                        .createdAt(photo.getPhotoCreate().toString())
+                        .build()
+                )
+                .collect(Collectors.toList());
+
+        return new PhotosResponseDto(photoList);
+    }
 }

--- a/src/main/java/com/Just_112_More/PicPle/stat/service/LocationStatService.java
+++ b/src/main/java/com/Just_112_More/PicPle/stat/service/LocationStatService.java
@@ -29,10 +29,11 @@ public class LocationStatService {
     private final LocationStatRepository locationStatRepository;
     private final PhotoService photoService;
 
-    public HotPlaceResponseList getTop10LocationStats() {
+    public HotPlaceResponseList calculateTop10FromDB() {
 
         // photoCnt가 높은 순으로 10개 조회
         List<LocationStat> topLocations = locationStatRepository.findTop10ByOrderByPhotoCntDesc();
+
         log.info("쿼리 결과: {}개", topLocations.size());
 
         List<HotPlaceResponse> results = new ArrayList<>();


### PR DESCRIPTION
## 💡 Issue
- Resolved: 

## 🌱 Key changes
<!--변경사항 적기-->
### 1. Top10 리스트 캐시구조 개선
- 초기화작업 : 서버 구동시 LocationStat 기준 Top10 리스트를 계산하여 Redis캐시에 저장
- `/v1/stat/top10` 요청 시 DB 쿼리 대신 캐시 데이터 반환하도록 변경 (조회 성능 향상)
- HotPlaceResponseList JSON 직렬화/역직렬화 로직 추가

### 2. 사진 업로드 → 통계 업데이트 → 커밋 이후 실시간 반영 
- `LocationStatService.uploadStat()` 내에서 `PhotoChangedEvent` 발행
- `@TransactionalEventListener(phase = AFTER_COMMIT)` 기반으로 커밋 완료 후 check&broadcast 실행
- 트랜잭션 커밋 실패 시 불필요한 broadcast 발생 방지

### 3. Top10 변경 감지 및 WebSocket 브로드캐스트
- Redis 캐시(`oldList`)와 DB 재계산 결과(`newList`) 비교 후, 실제 변경 시에만 broadcast 수행
- `@EqualsAndHashCode` 적용을 통한 `Objects.equals(oldList, newList)` 정확한 동등성 비교
- `/topic/hot-places` 구독 중인 클라이언트에만 변경사항 푸시

### 4. 조회/갱신 로직 분리
- Top10 리스트 조회와 행정동별 사진 목록 조회를 분리 (`/v1/stat/top10`, `/v1/stat/photo?location={locationLabel}`)
- 로직 간 의존도 축소 및 유지보수성 향상

### Additional Notes
- Redis Key: `top10::hotplaces`
- 최초 캐시 초기화 시점: `@PostConstruct` (`initTop10Cache()`)
- WebSocket 테스트 페이지 (`stomp.js` + `SockJS`)로 실시간 수신 확인 완료

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|
